### PR TITLE
Using bouncycastle instead of Java Cryptographic Extensions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,11 @@
             <version>2.3.3-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>1.54</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Because the Java Cryptographic Extensions require a special policy update within the system JDK, I changed the CryptTool to use the Bouncycastle Java API for encryption/decryption using Blowfish.